### PR TITLE
ENHANCEMENT: Highlight login link location

### DIFF
--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -157,7 +157,7 @@ function pmprosl_pmpro_user_fields() {
 		<div id="pmpro_social_login" class="pmpro_checkout">
 			<?php echo do_shortcode( '[wordpress_social_login]' ); ?>
 			<div class="pmpro_clear"></div>
-			<div id="pmpro_user_fields_show"><?php _e('or, <a id="pmpro_user_fields_a" href="javascript:void()">Click here to create a username and password</a>','pmpro'); ?></div>
+			<div id="pmpro_user_fields_show"><?php _e('or, <a id="pmpro_user_fields_a" href="javascript:void()">Click here to log in, create a username and password</a>','pmpro'); ?></div>
 		</div>
 		<script>
 			//show username and password fields 


### PR DESCRIPTION
The pre-existing text didn't indicate that the user had to click the link to access the user creation fields _and_ the link to log in.