### PR TITLE
Erroneous link for the Social Login Add On

### DIFF
--- a/languages/pmpro-social-login-en_EN.po
+++ b/languages/pmpro-social-login-en_EN.po
@@ -60,7 +60,7 @@ msgid "Paid Memberships Pro - Social Login Add On"
 msgstr ""
 
 #. Plugin URI of the plugin
-msgid "http://www.paidmembershipspro.com/wp/pmpro-social-login/"
+msgid "https://www.paidmembershipspro.com/add-ons/social-login-add-on/"
 msgstr ""
 
 #. Description of the plugin

--- a/languages/pmpro-social-login.po
+++ b/languages/pmpro-social-login.po
@@ -19,7 +19,7 @@ msgid "Paid Memberships Pro - Social Login Add On"
 msgstr ""
 
 #. Plugin URI of the plugin
-msgid "http://www.paidmembershipspro.com/wp/pmpro-social-login/"
+msgid "https://www.paidmembershipspro.com/add-ons/social-login-add-on/"
 msgstr ""
 
 #. Description of the plugin

--- a/languages/pmpro-social-login.pot
+++ b/languages/pmpro-social-login.pot
@@ -19,7 +19,7 @@ msgid "Paid Memberships Pro - Social Login Add On"
 msgstr ""
 
 #. Plugin URI of the plugin
-msgid "http://www.paidmembershipspro.com/wp/pmpro-social-login/"
+msgid "https://www.paidmembershipspro.com/add-ons/social-login-add-on/"
 msgstr ""
 
 #. Description of the plugin

--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Paid Memberships Pro - Social Login Add On
-Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-social-login/
+Plugin URI: https://www.paidmembershipspro.com/add-ons/social-login-add-on/
 Description: Allow users to create membership account via social networks.
 Version: 1.0
 Author: Stranger Studios


### PR DESCRIPTION
 * Replace old URI with suggested one

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-social-login/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-social-login/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Replace old URI with the suggested one.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves https://github.com/strangerstudios/paid-memberships-pro/issues/2620

### How to test the changes in this Pull Request:

This is tricky to test, because the uri is taken from license server. I'll need advice on how to do this. Not sure if we have an staging instance of license server.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?



### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
