### PR TITLE
Fix load textdomain notices

### DIFF
--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -292,5 +292,3 @@ function pmprosl_nsl_login_form_tweaks( $content, $args ) {
 
 }
 add_action( 'login_form_bottom', 'pmprosl_nsl_login_form_tweaks', 5, 2 );
-
-

--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -92,7 +92,7 @@ function pmprosl_check_plugins() {
 		update_option( 'pmpro_social_login_shortcode', $active_plugins[0]['shortcode'] );
 	}
 }
-add_action( 'plugins_loaded', 'pmprosl_check_plugins' );
+add_action( 'init', 'pmprosl_check_plugins' );
 
 /**
  * Check if a default level is set and if so, set it for new users created via social login.
@@ -293,3 +293,4 @@ function pmprosl_nsl_login_form_tweaks( $content, $args ) {
 
 }
 add_action( 'login_form_bottom', 'pmprosl_nsl_login_form_tweaks', 5, 2 );
+

--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -31,8 +31,7 @@ require_once( dirname(__FILE__) . '/includes/notices.php' );
  * Check what plugins are active and update settings.
  */
 function pmprosl_check_plugins() {
-	// Don't waste resources on the frontend.
-	if( ! is_admin() || ! defined( 'PMPRO_VERSION') ) {
+	if ( ! defined( 'PMPRO_VERSION' ) ) {
 		return;
 	}
 
@@ -92,7 +91,7 @@ function pmprosl_check_plugins() {
 		update_option( 'pmpro_social_login_shortcode', $active_plugins[0]['shortcode'] );
 	}
 }
-add_action( 'init', 'pmprosl_check_plugins' );
+add_action( 'admin_init', 'pmprosl_check_plugins' );
 
 /**
  * Check if a default level is set and if so, set it for new users created via social login.
@@ -293,4 +292,5 @@ function pmprosl_nsl_login_form_tweaks( $content, $args ) {
 
 }
 add_action( 'login_form_bottom', 'pmprosl_nsl_login_form_tweaks', 5, 2 );
+
 

--- a/pmpro-social-login.php
+++ b/pmpro-social-login.php
@@ -91,7 +91,7 @@ function pmprosl_check_plugins() {
 		update_option( 'pmpro_social_login_shortcode', $active_plugins[0]['shortcode'] );
 	}
 }
-add_action( 'admin_init', 'pmprosl_check_plugins' );
+add_action( 'admin_init', 'pmprosl_check_plugins', 9 );
 
 /**
  * Check if a default level is set and if so, set it for new users created via social login.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-social-login/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-social-login/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Performing installed plugins check on `admin_init` to stop loading translations for admin notices too early.

Resolves #28

### How to test the changes in this Pull Request:
1. Enable debugging.
2. Activate Social Login Add On.
3. Delete Nextend Social Login, Super Socializer, WordPress Social Login if any is installed.
4. Set site language to something other than English (US).
5. Observe `Translation loading for the pmpro-social-login domain was triggered too early` warnings on page load.
6. Apply PR.
7. Observe that warnings are no longer generated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed notices caused by translations loading before the `init` hook.
