### PR TITLE
Add nonce and capability checks to the dismiss-notice AJAX handler

### DIFF
--- a/includes/notices.php
+++ b/includes/notices.php
@@ -13,6 +13,7 @@ function pmprosl_admin_init_notifications() {
 	$admin_notice_dismissed = get_option( 'pmpro_social_login_notice_dismiss' );
 	if ( $admin_notice && ! $admin_notice_dismissed && ! $maybe_installing ) {
 		wp_enqueue_script( 'pmprosl-admin-dismiss-notice', plugin_dir_url(dirname(__FILE__)) . '/js/admin-dismiss-notice.js', array( 'jquery' ), PMPROSL_VERSION, true );
+		wp_localize_script( 'pmprosl-admin-dismiss-notice', 'pmprosl_dismiss_notice', array( 'nonce' => wp_create_nonce( 'pmprosl_dismiss_notice' ) ) );
 		add_action( 'admin_notices', 'pmprosl_admin_notice' );
 	}
 }
@@ -20,11 +21,16 @@ add_action( 'admin_init', 'pmprosl_admin_init_notifications' );
 
 // AJAX to handle notice dismissal
 function pmprosl_wp_ajax_dismiss_notice() {
+	check_ajax_referer( 'pmprosl_dismiss_notice', 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		exit;
+	}
+
 	// update option and leave
 	update_option('pmpro_social_login_notice_dismiss', 1);
 	exit;
 }
-add_action( 'wp_ajax_nopriv_pmprosl_dismiss_notice', 'pmprosl_wp_ajax_dismiss_notice' );
 add_action( 'wp_ajax_pmprosl_dismiss_notice', 'pmprosl_wp_ajax_dismiss_notice' );
 
 function pmprosl_admin_notice() {

--- a/includes/notices.php
+++ b/includes/notices.php
@@ -11,7 +11,7 @@ function pmprosl_admin_init_notifications() {
 	$maybe_installing = $script == 'update.php' || $script == 'plugins.php';
 	$admin_notice = get_option( 'pmpro_social_login_notice' );
 	$admin_notice_dismissed = get_option( 'pmpro_social_login_notice_dismiss' );
-	if ( $admin_notice && ! $admin_notice_dismissed && ! $maybe_installing ) {
+	if ( $admin_notice && ! $admin_notice_dismissed && ! $maybe_installing && current_user_can( 'manage_options' ) ) {
 		wp_enqueue_script( 'pmprosl-admin-dismiss-notice', plugin_dir_url(dirname(__FILE__)) . '/js/admin-dismiss-notice.js', array( 'jquery' ), PMPROSL_VERSION, true );
 		wp_localize_script( 'pmprosl-admin-dismiss-notice', 'pmprosl_dismiss_notice', array( 'nonce' => wp_create_nonce( 'pmprosl_dismiss_notice' ) ) );
 		add_action( 'admin_notices', 'pmprosl_admin_notice' );

--- a/js/admin-dismiss-notice.js
+++ b/js/admin-dismiss-notice.js
@@ -11,7 +11,7 @@ jQuery( document ).ready(
 						type:'POST',
 						timeout: 30000,
 						dataType: 'html',
-						data: 'action=pmprosl_dismiss_notice',
+						data: 'action=pmprosl_dismiss_notice&nonce=' + pmprosl_dismiss_notice.nonce,
 						error: function(xml){
 							alert( 'There was an error dismissing the PMPro Social Login notice.' );
 						},


### PR DESCRIPTION
The admin-notice dismissal endpoint was registered for both logged-in and logged-out requests with no validation. This PR:

- Removes the `wp_ajax_nopriv_` registration (the notice only displays in wp-admin anyway).
- Verifies a nonce, localized with the dismiss script.
- Requires `manage_options` before updating the dismissal option.

**Testing:** with the social login admin notice visible, dismiss it and confirm it stays dismissed.